### PR TITLE
Update generatorUtils.js

### DIFF
--- a/src/background/generator/generatorUtils.js
+++ b/src/background/generator/generatorUtils.js
@@ -179,7 +179,8 @@ class GeneratorUtils {
      */
     static urlFormatter(u, lists) {
         // make sure all urls are encoded
-        u = encodeURI(u);
+        if( u === decodeURIComponent(u))
+            u = encodeURI(u);
 
         // if SHEBANG
         if (u.indexOf('#!') > 0) {


### PR DESCRIPTION
I have encountered an error when a URL is encoded, this application will double encode it.

Example: https://www.lipseys.com/manufacturer/Inland%20Manufacturing
This Url would be encoded to "https://www.lipseys.com/manufacturer/Inland%2520Manufacturing" without a decoding check.

A fix is to decode the input URL and if the URL is not changed, it is already decoded, and can be encoded.